### PR TITLE
Add bottom navigation sections for Tasks, Health, and Chat

### DIFF
--- a/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
+++ b/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
@@ -1,26 +1,59 @@
 package com.organizen.app.auth.ui
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
 import com.organizen.app.auth.AuthViewModel
+import com.organizen.app.home.ui.ChatScreen
+import com.organizen.app.home.ui.HealthScreen
+import com.organizen.app.home.ui.TasksScreen
+import com.organizen.app.navigation.BottomNavScreen
 
 @Composable
 fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
-    Column(
-        Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.Center
-    ) {
-        Text("Welcome, ${vm.currentUser?.email ?: "User"}")
-        Button(onClick = {
-            vm.logout()
-            onLogout()
-        }) {
-            Text("Log Out")
+    val navController = rememberNavController()
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
+                val items = listOf(
+                    BottomNavScreen.Tasks,
+                    BottomNavScreen.Health,
+                    BottomNavScreen.Chat
+                )
+                items.forEach { screen ->
+                    NavigationBarItem(
+                        selected = currentRoute == screen.route,
+                        onClick = {
+                            navController.navigate(screen.route) {
+                                popUpTo(navController.graph.startDestinationId) { saveState = true }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        },
+                        label = { Text(screen.label) },
+                        icon = {}
+                    )
+                }
+            }
+        }
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = BottomNavScreen.Tasks.route,
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            composable(BottomNavScreen.Tasks.route) { TasksScreen(vm, onLogout) }
+            composable(BottomNavScreen.Health.route) { HealthScreen() }
+            composable(BottomNavScreen.Chat.route) { ChatScreen() }
         }
     }
 }

--- a/app/src/main/java/com/organizen/app/home/ui/Sections.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/Sections.kt
@@ -1,0 +1,52 @@
+package com.organizen.app.home.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.organizen.app.auth.AuthViewModel
+
+@Composable
+fun TasksScreen(vm: AuthViewModel, onLogout: () -> Unit) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text("Welcome, ${vm.currentUser?.email ?: "User"}")
+        Button(onClick = {
+            vm.logout()
+            onLogout()
+        }) {
+            Text("Log Out")
+        }
+    }
+}
+
+@Composable
+fun HealthScreen() {
+    Box(
+        Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Health section")
+    }
+}
+
+@Composable
+fun ChatScreen() {
+    Box(
+        Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Chat section")
+    }
+}

--- a/app/src/main/java/com/organizen/app/navigation/BottomNavScreen.kt
+++ b/app/src/main/java/com/organizen/app/navigation/BottomNavScreen.kt
@@ -1,0 +1,7 @@
+package com.organizen.app.navigation
+
+sealed class BottomNavScreen(val route: String, val label: String) {
+    object Tasks : BottomNavScreen("tasks", "Tasks")
+    object Health : BottomNavScreen("health", "Health")
+    object Chat : BottomNavScreen("chat", "Chat")
+}


### PR DESCRIPTION
## Summary
- Add BottomNavScreen sealed class for tasks, health, and chat routes
- Implement TasksScreen, HealthScreen, and ChatScreen composables
- Replace HomeScreen content with scaffold and bottom navigation

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f1be629488333a9214e165ecab3a7