### PR TITLE
Persist tasks

### DIFF
--- a/app/src/main/java/com/organizen/app/home/data/TasksViewModel.kt
+++ b/app/src/main/java/com/organizen/app/home/data/TasksViewModel.kt
@@ -1,24 +1,34 @@
 package com.organizen.app.home.data
 
+import android.app.Application
+import android.content.Context
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.LocalDate
 
-class TasksViewModel : ViewModel() {
+class TasksViewModel(application: Application) : AndroidViewModel(application) {
+    private val prefs = application.getSharedPreferences("tasks", Context.MODE_PRIVATE)
     private val tasksByUser = mutableStateMapOf<String, SnapshotStateList<Task>>()
 
     fun tasksFor(userId: String): SnapshotStateList<Task> =
-        tasksByUser.getOrPut(userId) { mutableStateListOf() }
+        tasksByUser.getOrPut(userId) {
+            mutableStateListOf<Task>().apply { addAll(loadTasks(userId)) }
+        }
 
     fun upsertTask(userId: String, task: Task) {
         val tasks = tasksFor(userId)
         val index = tasks.indexOfFirst { it.id == task.id }
         if (index >= 0) tasks[index] = task else tasks.add(task)
+        saveTasks(userId)
     }
 
     fun removeTask(userId: String, taskId: Long) {
         tasksFor(userId).removeAll { it.id == taskId }
+        saveTasks(userId)
     }
 
     fun setDone(userId: String, taskId: Long, done: Boolean) {
@@ -27,6 +37,50 @@ class TasksViewModel : ViewModel() {
         if (index >= 0) {
             val t = tasks[index]
             tasks[index] = t.copy(completed = done)
+            saveTasks(userId)
         }
     }
+
+    private fun loadTasks(userId: String): List<Task> {
+        val json = prefs.getString(userId, null) ?: return emptyList()
+        val arr = JSONArray(json)
+        val list = mutableListOf<Task>()
+        for (i in 0 until arr.length()) {
+            val o = arr.getJSONObject(i)
+            val tagsArr = o.getJSONArray("tags")
+            val tags = mutableListOf<Tag>()
+            for (j in 0 until tagsArr.length()) {
+                tags += Tag.valueOf(tagsArr.getString(j))
+            }
+            list += Task(
+                id = o.getLong("id"),
+                description = o.getString("description"),
+                difficulty = Difficulty.valueOf(o.getString("difficulty")),
+                estimatedMinutes = o.getInt("estimatedMinutes"),
+                tags = tags,
+                deadline = LocalDate.parse(o.getString("deadline")),
+                completed = o.getBoolean("completed")
+            )
+        }
+        return list
+    }
+
+    private fun saveTasks(userId: String) {
+        val arr = JSONArray()
+        tasksByUser[userId]?.forEach { task ->
+            val o = JSONObject()
+            o.put("id", task.id)
+            o.put("description", task.description)
+            o.put("difficulty", task.difficulty.name)
+            o.put("estimatedMinutes", task.estimatedMinutes)
+            val tagsArr = JSONArray()
+            task.tags.forEach { tagsArr.put(it.name) }
+            o.put("tags", tagsArr)
+            o.put("deadline", task.deadline.toString())
+            o.put("completed", task.completed)
+            arr.put(o)
+        }
+        prefs.edit().putString(userId, arr.toString()).apply()
+    }
 }
+

--- a/app/src/main/java/com/organizen/app/home/ui/TasksScreen.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/TasksScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -112,11 +111,18 @@ private fun TaskCard(task: Task, onCheckedChange: (Boolean) -> Unit, onClick: ()
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
-            .alpha(if (task.completed) 0.5f else 1f)
             .clickable { onClick() },
-        border = if (overdue) BorderStroke(1.dp, Color.Red) else null
+        border = if (overdue) BorderStroke(1.dp, Color.Red) else null,
+        colors = CardDefaults.cardColors(
+            containerColor = if (task.completed) Color.LightGray else MaterialTheme.colorScheme.surface
+        )
     ) {
-        Box(Modifier.fillMaxWidth().padding(8.dp)) {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .heightIn(min = 100.dp)
+                .padding(8.dp)
+        ) {
             Checkbox(
                 checked = task.completed,
                 onCheckedChange = onCheckedChange,
@@ -132,7 +138,11 @@ private fun TaskCard(task: Task, onCheckedChange: (Boolean) -> Unit, onClick: ()
                     Spacer(Modifier.width(4.dp))
                     Text(
                         task.description,
-                        color = if (overdue) Color.Red else Color.Unspecified
+                        color = when {
+                            overdue -> Color.Red
+                            task.completed -> Color.Gray
+                            else -> Color.Unspecified
+                        }
                     )
                 }
                 Spacer(Modifier.height(4.dp))


### PR DESCRIPTION
## Summary
- store user tasks in SharedPreferences so task lists persist after logout
- enlarge task card layout and make completed tasks gray, keeping overdue tasks red

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f46d563548333a48a0f8b860b2c97