### PR TITLE
Display daily steps and sleep from Samsung Health

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended")
     implementation(libs.androidx.navigation.compose)
     implementation(libs.material)
+    implementation("androidx.health.connect:connect-client:1.1.0-alpha08")
 
     // Splash Screen API
     implementation(libs.androidx.core.splashscreen)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.health.READ_STEPS" />
+    <uses-permission android:name="android.permission.health.READ_SLEEP" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/organizen/app/home/data/HealthViewModel.kt
+++ b/app/src/main/java/com/organizen/app/home/data/HealthViewModel.kt
@@ -1,0 +1,56 @@
+package com.organizen.app.home.data
+
+import android.app.Application
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.ReadRecordsRequest
+import androidx.health.connect.client.time.TimeRangeFilter
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.ZoneId
+
+class HealthViewModel(application: Application) : AndroidViewModel(application) {
+    private val client = HealthConnectClient.getOrCreate(application)
+
+    val steps = mutableStateOf<Long?>(null)
+    val sleepHours = mutableStateOf<Double?>(null)
+
+    val permissions = setOf(
+        HealthPermission.getReadPermission(StepsRecord::class),
+        HealthPermission.getReadPermission(SleepSessionRecord::class)
+    )
+
+    fun loadHealthData() {
+        viewModelScope.launch {
+            val today = LocalDate.now()
+            val zone = ZoneId.systemDefault()
+            val start = today.atStartOfDay(zone).toInstant()
+            val end = today.plusDays(1).atStartOfDay(zone).toInstant()
+
+            val stepsResult = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = StepsRecord::class,
+                    timeRangeFilter = TimeRangeFilter.between(start, end)
+                )
+            )
+            steps.value = stepsResult.records.sumOf { it.count }
+
+            val sleepResult = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = SleepSessionRecord::class,
+                    timeRangeFilter = TimeRangeFilter.between(start, end)
+                )
+            )
+            val totalSleepMillis = sleepResult.records.sumOf {
+                it.endTime.toEpochMilli() - it.startTime.toEpochMilli()
+            }
+            sleepHours.value = totalSleepMillis / (1000.0 * 60 * 60)
+        }
+    }
+}
+

--- a/app/src/main/java/com/organizen/app/home/ui/Sections.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/Sections.kt
@@ -1,23 +1,67 @@
 package com.organizen.app.home.ui
 
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.records.StepsRecord
+import com.organizen.app.home.data.HealthViewModel
 
 @Composable
-fun HealthScreen() {
+fun HealthScreen(vm: HealthViewModel = viewModel()) {
+    val context = LocalContext.current
+    val client = remember { HealthConnectClient.getOrCreate(context) }
+    val permissions = remember {
+        setOf(
+            HealthPermission.getReadPermission(StepsRecord::class),
+            HealthPermission.getReadPermission(SleepSessionRecord::class)
+        )
+    }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = client.permissionController.createRequestPermissionResultContract()
+    ) { granted ->
+        if (granted.containsAll(permissions)) {
+            vm.loadHealthData()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        val granted = client.permissionController.getGrantedPermissions(permissions)
+        if (!granted.containsAll(permissions)) {
+            launcher.launch(permissions)
+        } else {
+            vm.loadHealthData()
+        }
+    }
+
+    val steps by vm.steps
+    val sleepHours by vm.sleepHours
+
     Box(
         Modifier
             .fillMaxSize()
             .padding(16.dp),
         contentAlignment = Alignment.Center
     ) {
-        Text("Health section")
+        if (steps != null && sleepHours != null) {
+            Text("Steps: $steps\nSleep: ${String.format("%.1f", sleepHours)} h")
+        } else {
+            Text("Loading health data...")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- integrate Health Connect to pull today's steps and sleep and show them in Health screen
- add HealthViewModel to request data via Health Connect
- declare health permissions and include Health Connect dependency

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f636d62483339d09f9498bd4aa76