### PR TITLE
Show daily steps and sleep in card-based health section

### DIFF
--- a/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
+++ b/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
@@ -19,7 +19,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.organizen.app.auth.AuthViewModel
 import com.organizen.app.home.ui.ChatScreen
-import com.organizen.app.home.ui.HealthScreen
+import com.organizen.app.home.ui.HealthSection
 import com.organizen.app.home.ui.TasksScreen
 import com.organizen.app.home.ui.ProfileDrawerContent
 import com.organizen.app.navigation.BottomNavScreen
@@ -84,7 +84,7 @@ fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
                 modifier = Modifier.padding(innerPadding)
             ) {
                 composable(BottomNavScreen.Tasks.route) { TasksScreen(vm) }
-                composable(BottomNavScreen.Health.route) { HealthScreen() }
+                composable(BottomNavScreen.Health.route) { HealthSection() }
                 composable(BottomNavScreen.Chat.route) { ChatScreen() }
             }
         }

--- a/app/src/main/java/com/organizen/app/home/data/HealthViewModel.kt
+++ b/app/src/main/java/com/organizen/app/home/data/HealthViewModel.kt
@@ -1,0 +1,39 @@
+package com.organizen.app.home.data
+
+import android.app.Application
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+class HealthViewModel(application: Application) : AndroidViewModel(application) {
+    private val repo = HealthRepository(application)
+
+    var steps by mutableStateOf<Long?>(null)
+        private set
+    var sleepHours by mutableStateOf<Double?>(null)
+        private set
+
+    init {
+        viewModelScope.launch {
+            val zone = ZoneId.systemDefault()
+            val start = LocalDate.now().atStartOfDay(zone).toInstant()
+            val end = start.plus(1, ChronoUnit.DAYS)
+
+            val stepRecords = repo.readStepsInputs(start, end)
+            steps = stepRecords.sumOf { it.count.toLong() }
+
+            val sleepRecords = repo.readSleepInputs(start, end)
+            val totalSleepSeconds = sleepRecords.sumOf {
+                Duration.between(it.startTime, it.endTime).seconds
+            }
+            sleepHours = totalSleepSeconds / 3600.0
+        }
+    }
+}

--- a/app/src/main/java/com/organizen/app/home/ui/HealthSection.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/HealthSection.kt
@@ -1,0 +1,59 @@
+package com.organizen.app.home.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.organizen.app.home.data.HealthViewModel
+
+@Composable
+fun HealthSection(vm: HealthViewModel = viewModel()) {
+    if (vm.steps == null || vm.sleepHours == null) {
+        Box(
+            Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+    } else {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Card(Modifier.fillMaxWidth()) {
+                Column(
+                    Modifier
+                        .padding(16.dp)
+                        .fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text("Steps")
+                    Text(vm.steps.toString())
+                }
+            }
+            Card(Modifier.fillMaxWidth()) {
+                Column(
+                    Modifier
+                        .padding(16.dp)
+                        .fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text("Sleep")
+                    Text(String.format("%.1f h", vm.sleepHours))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/organizen/app/home/ui/Sections.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/Sections.kt
@@ -10,18 +10,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun HealthScreen() {
-    Box(
-        Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        contentAlignment = Alignment.Center
-    ) {
-        Text("Health section")
-    }
-}
-
-@Composable
 fun ChatScreen() {
     Box(
         Modifier


### PR DESCRIPTION
## Summary
- replace text with two cards showing today's steps and sleep hours
- move Health UI into its own `HealthSection` composable and update navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a36621101c83338716d23c3978b264