### PR TITLE
Recommend tasks based on health metrics

### DIFF
--- a/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
+++ b/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
@@ -18,7 +18,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.organizen.app.auth.AuthViewModel
-import com.organizen.app.home.ui.ChatScreen
 import com.organizen.app.home.ui.HealthSection
 import com.organizen.app.home.ui.TasksScreen
 import com.organizen.app.home.ui.ProfileDrawerContent
@@ -26,6 +25,8 @@ import com.organizen.app.navigation.BottomNavScreen
 import com.organizen.app.R
 import com.organizen.app.home.ui.ChatSection
 import kotlinx.coroutines.launch
+import com.organizen.app.home.data.ChatViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -33,6 +34,7 @@ fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
     val navController = rememberNavController()
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
+    val chatViewModel: ChatViewModel = viewModel()
     ModalNavigationDrawer(
         drawerState = drawerState,
         drawerContent = {
@@ -85,8 +87,8 @@ fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
                 modifier = Modifier.padding(innerPadding)
             ) {
                 composable(BottomNavScreen.Tasks.route) { TasksScreen(vm) }
-                composable(BottomNavScreen.Health.route) { HealthSection() }
-                composable(BottomNavScreen.Chat.route) { ChatSection() }
+                composable(BottomNavScreen.Health.route) { HealthSection(vm, navController, chatViewModel) }
+                composable(BottomNavScreen.Chat.route) { ChatSection(chatViewModel = chatViewModel) }
             }
         }
     }

--- a/app/src/main/java/com/organizen/app/home/ui/ChatSection.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/ChatSection.kt
@@ -32,11 +32,12 @@ import androidx.compose.ui.unit.dp
 import com.organizen.app.home.data.ChatViewModel
 import com.organizen.app.home.models.Message
 import com.organizen.app.home.models.MessageType
+import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Composable
 fun ChatSection(
     modifier: Modifier = Modifier,
-    chatViewModel: ChatViewModel = remember { ChatViewModel() },
+    chatViewModel: ChatViewModel = viewModel(),
 ) {
     val uiState by chatViewModel.uiState.collectAsState()
     val listState = rememberLazyListState()

--- a/app/src/main/java/com/organizen/app/home/ui/HealthSection.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/HealthSection.kt
@@ -15,10 +15,23 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.organizen.app.auth.AuthViewModel
+import com.organizen.app.home.data.ChatViewModel
 import com.organizen.app.home.data.HealthViewModel
+import com.organizen.app.home.data.TasksViewModel
+import com.organizen.app.home.data.Difficulty
+import java.time.LocalDate
+import com.organizen.app.navigation.BottomNavScreen
 
 @Composable
-fun HealthSection(vm: HealthViewModel = viewModel()) {
+fun HealthSection(
+    authVm: AuthViewModel,
+    navController: NavController,
+    chatViewModel: ChatViewModel,
+    vm: HealthViewModel = viewModel(),
+    tasksVm: TasksViewModel = viewModel()
+) {
     if (vm.steps == null || vm.sleepHours == null) {
         Box(
             Modifier.fillMaxSize(),
@@ -27,6 +40,17 @@ fun HealthSection(vm: HealthViewModel = viewModel()) {
             CircularProgressIndicator()
         }
     } else {
+        val userId = authVm.currentUser?.uid ?: "guest"
+        val tasks = tasksVm.tasksFor(userId)
+        val available = tasks.filter { !it.completed && !it.deadline.isBefore(LocalDate.now()) }
+        val tired = vm.steps!! < 5000 || vm.sleepHours!! < 7.0
+        val recommended = if (tired) {
+            available.filter { it.difficulty == Difficulty.EASY || it.estimatedMinutes <= 30 }
+                .minByOrNull { it.estimatedMinutes }
+        } else {
+            available.filter { it.difficulty == Difficulty.HARD || it.estimatedMinutes >= 60 }
+                .maxByOrNull { it.estimatedMinutes }
+        }
         Column(
             Modifier
                 .fillMaxSize()
@@ -55,10 +79,30 @@ fun HealthSection(vm: HealthViewModel = viewModel()) {
                     Text(String.format("%.1f h", vm.sleepHours))
                 }
             }
-            Button(onClick = {
-                vm.recommend()
-            }) {
-                Text("asds")
+            recommended?.let { task ->
+                Card(Modifier.fillMaxWidth()) {
+                    Column(
+                        Modifier
+                            .padding(16.dp)
+                            .fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text("Recommended task")
+                        Text(task.description)
+                        Button(onClick = {
+                            val prompt = if (tired) {
+                                "Suggest a short relaxation exercise."
+                            } else {
+                                "Give me a productivity advice to stay focused."
+                            }
+                            chatViewModel.sendMessage(prompt)
+                            navController.navigate(BottomNavScreen.Chat.route)
+                        }) {
+                            Text(if (tired) "Get relax recommendations" else "Get productivity advices")
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Suggest a task on the Health screen using steps and sleep data
- Share a single chat view model and navigate to chat for advice prompts
- Simplify ChatSection view model management

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ab68c6688333a454e1b0926a8461