### PR TITLE
Add productivity targets and polish UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     id("com.google.gms.google-services")
-//    alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.compose.compiler)
 }
 
@@ -37,7 +36,6 @@ android {
             )
         }
     }
-//    composeOptions { kotlinCompilerExtensionVersion = "1.5.15" }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
@@ -58,61 +56,11 @@ android {
     }
 }
 
-//dependencies {
-//
-//    implementation(libs.androidx.core.ktx)
-//    implementation(libs.androidx.appcompat)
-////    implementation(libs.material)
-//
-//    // Compose
-//    implementation(platform(libs.androidx.compose.bom))
-//    implementation (libs.google.firebase.auth.ktx)
-////    implementation(libs.androidx.activity)
-//    implementation(libs.androidx.activity.compose)
-//    implementation(libs.androidx.navigation.compose)
-//    implementation(libs.androidx.material3)
-////    implementation(libs.androidx.constraintlayout) //xml
-//    implementation(libs.androidx.core.splashscreen)
-//    implementation(libs.kotlinx.coroutines.play.services)
-//
-//
-//    implementation(platform(libs.firebase.bom))
-//    implementation(libs.firebaseAuthKtx)
-//
-//    testImplementation(libs.junit)
-//    androidTestImplementation(libs.androidx.junit)
-//    androidTestImplementation(libs.androidx.espresso.core)
-//}
-
-//dependencies {
-//    // Android de bază
-//    implementation(libs.androidx.core.ktx)
-//    implementation(libs.androidx.appcompat) // poți renunța dacă nu ai niciun ecran pe Views
-//
-//    // Compose
-//    implementation(platform(libs.androidx.compose.bom))
-//    implementation(libs.androidx.activity.compose)
-//    implementation(libs.androidx.navigation.compose)
-//    implementation(libs.androidx.material3)
-//
-//    // Splash screen API
-//    implementation(libs.androidx.core.splashscreen)
-//
-//    // Firebase Auth + coroutines-play-services (pentru await())
-//    implementation(platform(libs.firebase.bom))
-//    implementation(libs.firebase.auth.ktx) // <- vezi să folosești numele exact din TOML: libs.firebase-auth-ktx
-//    implementation(libs.kotlinx.coroutines.play.services)
-//
-//    // Teste
-//    testImplementation(libs.junit)
-//    androidTestImplementation(libs.androidx.junit)
-//    androidTestImplementation(libs.androidx.espresso.core)
-//}
 
 dependencies {
     // Android de bază
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.appcompat)                 // poți elimina dacă e 100% Compose
+    implementation(libs.androidx.appcompat)
 
     // Compose
     implementation(platform(libs.androidx.compose.bom))
@@ -129,21 +77,13 @@ dependencies {
     // Firebase Auth (+ BOM)
     implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
     implementation("com.google.firebase:firebase-auth")
+
     implementation(libs.koog.agents)
-//    implementation(platform(libs.firebase.bom))
-//    implementation(libs.firebase.auth.ktx)
-//    implementation(platform("com.google.firebase:firebase-bom:32.8.0")) // Or the latest BoM version
-//    implementation("com.google.firebase:firebase-auth-ktx")
-
-    // await() pentru Task (Firebase)
     implementation(libs.kotlinx.coroutines.play.services)
-//    implementation(libs.google.firebase.auth.ktx)
-//    implementation(libs.google.firebase.auth.ktx)
-
     // Add a dependency of Health Connect SDK
     implementation (libs.androidx.connect.client)
 
-//    // Teste
+    // Teste
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
+++ b/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
@@ -13,12 +13,13 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.style.TextAlign
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.organizen.app.auth.AuthViewModel
-import com.organizen.app.home.ui.HealthSection
+import com.organizen.app.home.ui.ProductivitySection
 import com.organizen.app.home.ui.TasksScreen
 import com.organizen.app.home.ui.ProfileDrawerContent
 import com.organizen.app.navigation.BottomNavScreen
@@ -28,7 +29,13 @@ import kotlinx.coroutines.launch
 import com.organizen.app.home.data.ChatViewModel
 import com.organizen.app.home.data.TasksViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import android.os.Build
+import androidx.annotation.RequiresApi
 
+@RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
@@ -47,10 +54,19 @@ fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
             }
         }
     ) {
+        val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
+        val title = when (currentRoute) {
+            BottomNavScreen.Tasks.route -> "My tasks"
+            BottomNavScreen.Productivity.route -> LocalDate.now().format(DateTimeFormatter.ofPattern("dd MMMM yyyy", Locale.getDefault()))
+            BottomNavScreen.Chat.route -> "OrganiZen assistant"
+            else -> ""
+        }
         Scaffold(
             topBar = {
                 TopAppBar(
-                    title = {},
+                    title = {
+                        Text(title, modifier = Modifier.fillMaxWidth(), textAlign = TextAlign.Center, style = MaterialTheme.typography.titleLarge)
+                    },
                     navigationIcon = {
                         IconButton(onClick = { scope.launch { drawerState.open() } }) {
                             Image(painterResource(R.drawable.organizen_icon), contentDescription = "Profile")
@@ -60,10 +76,9 @@ fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
             },
             bottomBar = {
                 NavigationBar {
-                    val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
                     val items = listOf(
                         BottomNavScreen.Tasks,
-                        BottomNavScreen.Health,
+                        BottomNavScreen.Productivity,
                         BottomNavScreen.Chat
                     )
                     items.forEach { screen ->
@@ -89,7 +104,7 @@ fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
                 modifier = Modifier.padding(innerPadding)
             ) {
                 composable(BottomNavScreen.Tasks.route) { TasksScreen(vm, tasksViewModel) }
-                composable(BottomNavScreen.Health.route) { HealthSection(vm, navController, chatViewModel, tasksViewModel) }
+                composable(BottomNavScreen.Productivity.route) { ProductivitySection(vm, navController, chatViewModel, tasksViewModel) }
                 composable(BottomNavScreen.Chat.route) { ChatSection(chatViewModel = chatViewModel) }
             }
         }

--- a/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
+++ b/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.font.FontWeight
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -63,9 +64,14 @@ fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
         }
         Scaffold(
             topBar = {
-                TopAppBar(
+                CenterAlignedTopAppBar(
                     title = {
-                        Text(title, modifier = Modifier.fillMaxWidth(), textAlign = TextAlign.Center, style = MaterialTheme.typography.titleLarge)
+                        Text(
+                            title,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.Bold,
+                            textAlign = TextAlign.Center
+                        )
                     },
                     navigationIcon = {
                         IconButton(onClick = { scope.launch { drawerState.open() } }) {

--- a/app/src/main/java/com/organizen/app/auth/ui/LoginScreen.kt
+++ b/app/src/main/java/com/organizen/app/auth/ui/LoginScreen.kt
@@ -9,6 +9,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.ui.unit.dp
 import com.organizen.app.R
 import com.organizen.app.auth.AuthViewModel
@@ -22,6 +26,7 @@ fun LoginScreen(
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
+    var passwordVisible by remember { mutableStateOf(false) }
 
     Column(
         Modifier
@@ -45,7 +50,13 @@ fun LoginScreen(
         OutlinedTextField(
             value = password, onValueChange = { password = it },
             label = { Text("Password") },
-            visualTransformation = PasswordVisualTransformation(),
+            visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+                val image = if (passwordVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff
+                IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                    Icon(image, contentDescription = if (passwordVisible) "Hide password" else "Show password")
+                }
+            },
             modifier = Modifier.fillMaxWidth(0.8f)
         )
 

--- a/app/src/main/java/com/organizen/app/auth/ui/RegisterScreen.kt
+++ b/app/src/main/java/com/organizen/app/auth/ui/RegisterScreen.kt
@@ -9,6 +9,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.ui.unit.dp
 import com.organizen.app.R
 import com.organizen.app.auth.AuthViewModel
@@ -24,6 +28,8 @@ fun RegisterScreen(
     var password by remember { mutableStateOf("") }
     var confirmPassword by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
+    var passwordVisible by remember { mutableStateOf(false) }
+    var confirmPasswordVisible by remember { mutableStateOf(false) }
 
     Column(
         Modifier
@@ -51,13 +57,25 @@ fun RegisterScreen(
         OutlinedTextField(
             value = password, onValueChange = { password = it },
             label = { Text("Password") },
-            visualTransformation = PasswordVisualTransformation(),
+            visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+                val image = if (passwordVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff
+                IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                    Icon(image, contentDescription = if (passwordVisible) "Hide password" else "Show password")
+                }
+            },
             modifier = Modifier.fillMaxWidth(0.8f)
         )
         OutlinedTextField(
             value = confirmPassword, onValueChange = { confirmPassword = it },
             label = { Text("Confirm Password") },
-            visualTransformation = PasswordVisualTransformation(),
+            visualTransformation = if (confirmPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+                val image = if (confirmPasswordVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff
+                IconButton(onClick = { confirmPasswordVisible = !confirmPasswordVisible }) {
+                    Icon(image, contentDescription = if (confirmPasswordVisible) "Hide password" else "Show password")
+                }
+            },
             modifier = Modifier.fillMaxWidth(0.8f)
         )
 

--- a/app/src/main/java/com/organizen/app/home/data/HealthViewModel.kt
+++ b/app/src/main/java/com/organizen/app/home/data/HealthViewModel.kt
@@ -9,6 +9,7 @@ import ai.koog.agents.core.tools.reflect.tools
 import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
 import ai.koog.prompt.llm.OllamaModels
 import android.app.Application
+import android.content.Context
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,14 +26,15 @@ import java.time.temporal.ChronoUnit
 
 class HealthViewModel(application: Application) : AndroidViewModel(application) {
     private val repo = HealthRepository(application)
+    private val prefs = application.getSharedPreferences("targets", Context.MODE_PRIVATE)
 
     var steps by mutableStateOf<Long?>(null)
         private set
     var sleepHours by mutableStateOf<Double?>(null)
         private set
-    var stepsGoal by mutableStateOf(5000f)
+    var stepsGoal by mutableStateOf(prefs.getFloat("stepsGoal", 5000f))
         private set
-    var sleepGoal by mutableStateOf(7.0)
+    var sleepGoal by mutableStateOf(prefs.getFloat("sleepGoal", 7f).toDouble())
         private set
 
     init {
@@ -52,8 +54,14 @@ class HealthViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
-    fun updateStepsGoal(value: Float) { stepsGoal = value }
-    fun updateSleepGoal(value: Double) { sleepGoal = value }
+    fun updateStepsGoal(value: Float) {
+        stepsGoal = value
+        prefs.edit().putFloat("stepsGoal", value).apply()
+    }
+    fun updateSleepGoal(value: Double) {
+        sleepGoal = value
+        prefs.edit().putFloat("sleepGoal", value.toFloat()).apply()
+    }
 
     fun recommend() {
         val agent = AIAgent(

--- a/app/src/main/java/com/organizen/app/home/data/HealthViewModel.kt
+++ b/app/src/main/java/com/organizen/app/home/data/HealthViewModel.kt
@@ -30,6 +30,10 @@ class HealthViewModel(application: Application) : AndroidViewModel(application) 
         private set
     var sleepHours by mutableStateOf<Double?>(null)
         private set
+    var stepsGoal by mutableStateOf(5000f)
+        private set
+    var sleepGoal by mutableStateOf(7.0)
+        private set
 
     init {
         viewModelScope.launch {
@@ -47,6 +51,9 @@ class HealthViewModel(application: Application) : AndroidViewModel(application) 
             sleepHours = totalSleepSeconds / 3600.0
         }
     }
+
+    fun updateStepsGoal(value: Float) { stepsGoal = value }
+    fun updateSleepGoal(value: Double) { sleepGoal = value }
 
     fun recommend() {
         val agent = AIAgent(

--- a/app/src/main/java/com/organizen/app/home/data/TasksViewModel.kt
+++ b/app/src/main/java/com/organizen/app/home/data/TasksViewModel.kt
@@ -22,7 +22,11 @@ class TasksViewModel(application: Application) : AndroidViewModel(application) {
     fun upsertTask(userId: String, task: Task) {
         val tasks = tasksFor(userId)
         val index = tasks.indexOfFirst { it.id == task.id }
-        if (index >= 0) tasks[index] = task else tasks.add(task)
+        if (index >= 0) {
+            tasks[index] = task
+        } else {
+            if (task.completed) tasks.add(task) else tasks.add(0, task)
+        }
         saveTasks(userId)
     }
 
@@ -35,8 +39,8 @@ class TasksViewModel(application: Application) : AndroidViewModel(application) {
         val tasks = tasksFor(userId)
         val index = tasks.indexOfFirst { it.id == taskId }
         if (index >= 0) {
-            val t = tasks[index]
-            tasks[index] = t.copy(completed = done)
+            val t = tasks.removeAt(index).copy(completed = done)
+            if (done) tasks.add(t) else tasks.add(0, t)
             saveTasks(userId)
         }
     }

--- a/app/src/main/java/com/organizen/app/home/ui/ProductivitySection.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/ProductivitySection.kt
@@ -38,7 +38,7 @@ import kotlin.math.roundToInt
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun HealthSection(
+fun ProductivitySection(
     authVm: AuthViewModel,
     navController: NavController,
     chatViewModel: ChatViewModel,
@@ -57,7 +57,7 @@ fun HealthSection(
     val available = tasks.filter { !it.completed && !it.deadline.isBefore(LocalDate.now()) }
 
     // Consider the user tired only when today's sleep is low or they have already walked a lot
-    val tired = vm.sleepHours!! < 7.0 || vm.steps!! > 5000
+    val tired = vm.sleepHours!! < vm.sleepGoal || vm.steps!! > vm.stepsGoal
     val recommended = if (available.isNotEmpty()) {
         val easiest = available.minByOrNull { it.difficulty.ordinal }
         val shortest = available.minByOrNull { it.estimatedMinutes }
@@ -76,13 +76,9 @@ fun HealthSection(
     val sleepHoursPart = sleepMinutes / 60
     val sleepMinutesPart = sleepMinutes % 60
 
-    // goals
-    val stepsGoal = 5000f
-    val sleepGoal = 7.0
-
     // progress (0..1)
-    val stepsProgress = (vm.steps!! / stepsGoal).coerceIn(0f, 1f)
-    val sleepProgress = (vm.sleepHours!! / sleepGoal).toFloat().coerceIn(0f, 1f)
+    val stepsProgress = (vm.steps!!.toFloat() / vm.stepsGoal).coerceIn(0f, 1f)
+    val sleepProgress = (vm.sleepHours!! / vm.sleepGoal).toFloat().coerceIn(0f, 1f)
 
     val scroll = rememberScrollState()
 
@@ -104,7 +100,7 @@ fun HealthSection(
                 title = "Steps",
                 icon = Icons.Filled.DirectionsWalk,
                 centerTop = "%,d".format(vm.steps),
-                centerBottom = "of ${stepsGoal.toInt()}",
+                centerBottom = "of ${vm.stepsGoal.toInt()}",
                 progress = stepsProgress,
                 ringSize = 140.dp,      // mai mic să încapă două pe un rând
                 ringStroke = 12.dp,
@@ -118,7 +114,7 @@ fun HealthSection(
                 title = "Sleep",
                 icon = Icons.Filled.Bedtime,
                 centerTop = "${sleepHoursPart}h ${sleepMinutesPart}m",
-                centerBottom = "goal ${sleepGoal.toInt()}h",
+                centerBottom = "goal ${vm.sleepGoal.toInt()}h",
                 progress = sleepProgress,
                 ringSize = 140.dp,
                 ringStroke = 12.dp,

--- a/app/src/main/java/com/organizen/app/home/ui/ProfileDrawer.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/ProfileDrawer.kt
@@ -4,14 +4,21 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.organizen.app.auth.AuthViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.organizen.app.home.data.HealthViewModel
 
 @Composable
 fun ProfileDrawerContent(vm: AuthViewModel, onLogout: () -> Unit, onClose: () -> Unit) {
@@ -20,6 +27,9 @@ fun ProfileDrawerContent(vm: AuthViewModel, onLogout: () -> Unit, onClose: () ->
     var editingName by remember { mutableStateOf(false) }
     var showPasswordDialog by remember { mutableStateOf(false) }
     var showSuccessDialog by remember { mutableStateOf(false) }
+    val healthVm: HealthViewModel = viewModel()
+    var stepsTargetText by remember { mutableStateOf(healthVm.stepsGoal.toInt().toString()) }
+    var sleepTargetText by remember { mutableStateOf(healthVm.sleepGoal.toString()) }
 
     Column(
         modifier = Modifier
@@ -49,6 +59,31 @@ fun ProfileDrawerContent(vm: AuthViewModel, onLogout: () -> Unit, onClose: () ->
             Button(onClick = { showPasswordDialog = true }) {
                 Text("Change Password")
             }
+
+            Spacer(Modifier.height(24.dp))
+            Text("Set your targets", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = stepsTargetText,
+                onValueChange = {
+                    stepsTargetText = it
+                    it.toFloatOrNull()?.let { value -> healthVm.updateStepsGoal(value) }
+                },
+                label = { Text("Steps target") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = sleepTargetText,
+                onValueChange = {
+                    sleepTargetText = it
+                    it.toDoubleOrNull()?.let { value -> healthVm.updateSleepGoal(value) }
+                },
+                label = { Text("Sleep hours target") },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
         }
 
         Button(
@@ -65,6 +100,8 @@ fun ProfileDrawerContent(vm: AuthViewModel, onLogout: () -> Unit, onClose: () ->
         var password by remember { mutableStateOf("") }
         var confirm by remember { mutableStateOf("") }
         var error by remember { mutableStateOf<String?>(null) }
+        var passwordVisible by remember { mutableStateOf(false) }
+        var confirmVisible by remember { mutableStateOf(false) }
 
         AlertDialog(
             onDismissRequest = { showPasswordDialog = false },
@@ -75,14 +112,26 @@ fun ProfileDrawerContent(vm: AuthViewModel, onLogout: () -> Unit, onClose: () ->
                         value = password,
                         onValueChange = { password = it },
                         label = { Text("Password") },
-                        visualTransformation = PasswordVisualTransformation(),
+                        visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                        trailingIcon = {
+                            val image = if (passwordVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff
+                            IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                                Icon(image, contentDescription = if (passwordVisible) "Hide password" else "Show password")
+                            }
+                        },
                         modifier = Modifier.fillMaxWidth()
                     )
                     OutlinedTextField(
                         value = confirm,
                         onValueChange = { confirm = it },
                         label = { Text("Confirm Password") },
-                        visualTransformation = PasswordVisualTransformation(),
+                        visualTransformation = if (confirmVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                        trailingIcon = {
+                            val image = if (confirmVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff
+                            IconButton(onClick = { confirmVisible = !confirmVisible }) {
+                                Icon(image, contentDescription = if (confirmVisible) "Hide password" else "Show password")
+                            }
+                        },
                         modifier = Modifier.fillMaxWidth()
                     )
                     error?.let { Text(it, color = Color.Red) }

--- a/app/src/main/java/com/organizen/app/home/ui/ProfileDrawer.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/ProfileDrawer.kt
@@ -28,7 +28,9 @@ fun ProfileDrawerContent(vm: AuthViewModel, onLogout: () -> Unit, onClose: () ->
     var showPasswordDialog by remember { mutableStateOf(false) }
     var showSuccessDialog by remember { mutableStateOf(false) }
     val healthVm: HealthViewModel = viewModel()
+    var editingSteps by remember { mutableStateOf(false) }
     var stepsTargetText by remember { mutableStateOf(healthVm.stepsGoal.toInt().toString()) }
+    var editingSleep by remember { mutableStateOf(false) }
     var sleepTargetText by remember { mutableStateOf(healthVm.sleepGoal.toString()) }
 
     Column(
@@ -63,26 +65,36 @@ fun ProfileDrawerContent(vm: AuthViewModel, onLogout: () -> Unit, onClose: () ->
             Spacer(Modifier.height(24.dp))
             Text("Set your targets", style = MaterialTheme.typography.titleMedium)
             Spacer(Modifier.height(8.dp))
-            OutlinedTextField(
-                value = stepsTargetText,
-                onValueChange = {
-                    stepsTargetText = it
-                    it.toFloatOrNull()?.let { value -> healthVm.updateStepsGoal(value) }
+            EditableRow(
+                value = if (editingSteps) stepsTargetText else healthVm.stepsGoal.toInt().toString(),
+                editing = editingSteps,
+                label = "Steps target",
+                onValueChange = { stepsTargetText = it },
+                onEdit = {
+                    stepsTargetText = healthVm.stepsGoal.toInt().toString()
+                    editingSteps = true
                 },
-                label = { Text("Steps target") },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                modifier = Modifier.fillMaxWidth()
+                onSave = {
+                    stepsTargetText.toFloatOrNull()?.let { healthVm.updateStepsGoal(it) }
+                    editingSteps = false
+                },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
             Spacer(Modifier.height(8.dp))
-            OutlinedTextField(
-                value = sleepTargetText,
-                onValueChange = {
-                    sleepTargetText = it
-                    it.toDoubleOrNull()?.let { value -> healthVm.updateSleepGoal(value) }
+            EditableRow(
+                value = if (editingSleep) sleepTargetText else healthVm.sleepGoal.toString(),
+                editing = editingSleep,
+                label = "Sleep hours target",
+                onValueChange = { sleepTargetText = it },
+                onEdit = {
+                    sleepTargetText = healthVm.sleepGoal.toString()
+                    editingSleep = true
                 },
-                label = { Text("Sleep hours target") },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                modifier = Modifier.fillMaxWidth()
+                onSave = {
+                    sleepTargetText.toDoubleOrNull()?.let { healthVm.updateSleepGoal(it) }
+                    editingSleep = false
+                },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
         }
 
@@ -190,6 +202,7 @@ private fun EditableRow(
     onValueChange: (String) -> Unit,
     onEdit: () -> Unit,
     onSave: () -> Unit,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
 ) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         if (editing) {
@@ -197,7 +210,8 @@ private fun EditableRow(
                 value = value,
                 onValueChange = onValueChange,
                 modifier = Modifier.weight(1f),
-                label = { Text(label) }
+                label = { Text(label) },
+                keyboardOptions = keyboardOptions
             )
             IconButton(onClick = onSave) {
                 Icon(Icons.Filled.Check, contentDescription = "Save")

--- a/app/src/main/java/com/organizen/app/home/ui/TasksScreen.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/TasksScreen.kt
@@ -310,7 +310,6 @@ fun TaskCard(task: Task, onCheckedChange: (Boolean) -> Unit, onClick: () -> Unit
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onClick() },
-        border = if (overdue) BorderStroke(1.dp, Color.Red) else null,
         colors = CardDefaults.cardColors(
             containerColor = if (task.completed) Color.LightGray else categoryColors[task.category] ?: MaterialTheme.colorScheme.surface
         )
@@ -374,18 +373,10 @@ fun TaskCard(task: Task, onCheckedChange: (Boolean) -> Unit, onClick: () -> Unit
                 )
                 Spacer(Modifier.width(2.dp))
                 Text("${task.estimatedMinutes}m", style = MaterialTheme.typography.bodySmall)
-                if (dueToday) {
-                    Spacer(Modifier.width(4.dp))
-                    Icon(
-                        Icons.Default.PriorityHigh,
-                        contentDescription = "Due today",
-                        tint = Color.Red,
-                        modifier = Modifier.size(16.dp)
-                    )
-                }
             }
             Text(
-                task.deadline.toString(),
+                if (dueToday) "Today" else task.deadline.toString(),
+                color = if (dueToday) Color.Red else Color.Unspecified,
                 modifier = Modifier.align(Alignment.BottomEnd),
                 style = MaterialTheme.typography.bodySmall
             )

--- a/app/src/main/java/com/organizen/app/navigation/BottomNavScreen.kt
+++ b/app/src/main/java/com/organizen/app/navigation/BottomNavScreen.kt
@@ -2,6 +2,6 @@ package com.organizen.app.navigation
 
 sealed class BottomNavScreen(val route: String, val label: String) {
     object Tasks : BottomNavScreen("tasks", "Tasks")
-    object Health : BottomNavScreen("health", "Health")
+    object Productivity : BottomNavScreen("productivity", "Productivity")
     object Chat : BottomNavScreen("chat", "Chat")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,12 +1,5 @@
 pluginManagement {
     repositories {
-//        google {
-//            content {
-//                includeGroupByRegex("com\\.android.*")
-//                includeGroupByRegex("com\\.google.*")
-//                includeGroupByRegex("androidx.*")
-//            }
-//        }
         google()
         mavenCentral()
         gradlePluginPortal()


### PR DESCRIPTION
## Summary
- Toggle password visibility on login, registration, and password change dialogs
- Introduce editable step and sleep targets and rename Health section to Productivity
- Display centered titles per screen and highlight tasks due today without red borders

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a588bfaed08333849b62ad09c89efe