### PR TITLE
Add task reminder notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,11 +26,15 @@
             </intent-filter>
         </activity>
 
+        <receiver
+            android:name=".notifications.TaskReminderReceiver"
+            android:exported="false" />
     </application>
+
     <uses-permission android:name="android.permission.health.READ_STEPS"/>
     <uses-permission android:name="android.permission.health.WRITE_STEPS"/>
     <uses-permission android:name="android.permission.health.READ_SLEEP"/>
     <uses-permission android:name="android.permission.health.WRITE_SLEEP"/>
-
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
 </manifest>

--- a/app/src/main/java/com/organizen/app/MainActivity.kt
+++ b/app/src/main/java/com/organizen/app/MainActivity.kt
@@ -10,6 +10,7 @@ import com.organizen.app.auth.AuthViewModel
 import com.organizen.app.home.data.HealthRepository
 import com.organizen.app.navigation.AppNavGraph
 import com.organizen.app.theme.OrganiZenTheme
+import com.organizen.app.notifications.TaskReminderReceiver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -24,6 +25,7 @@ class MainActivity : ComponentActivity() {
             val repo = HealthRepository(this@MainActivity)
             repo.readStepsInputs(Instant.now().minusSeconds(235673433), Instant.now())
         }
+        TaskReminderReceiver.schedule(this)
         // icon animation after splash screen
         splash.setOnExitAnimationListener { splashViewProvider ->
             val v = splashViewProvider.iconView

--- a/app/src/main/java/com/organizen/app/notifications/TaskReminderReceiver.kt
+++ b/app/src/main/java/com/organizen/app/notifications/TaskReminderReceiver.kt
@@ -1,0 +1,63 @@
+package com.organizen.app.notifications
+
+import android.app.AlarmManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.SystemClock
+import androidx.core.app.NotificationCompat
+import com.organizen.app.R
+
+class TaskReminderReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        val channelId = CHANNEL_ID
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                channelId,
+                "Task Reminder",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        val notification = NotificationCompat.Builder(context, channelId)
+            .setSmallIcon(R.drawable.organizen_icon)
+            .setContentTitle("Be productive")
+            .setContentText("Be productive and check a task")
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(NOTIFICATION_ID, notification)
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "task_reminder_channel"
+        private const val NOTIFICATION_ID = 1001
+        private const val INTERVAL_MILLIS = 10 * 60 * 1000L
+
+        fun schedule(context: Context) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val intent = Intent(context, TaskReminderReceiver::class.java)
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE
+            )
+
+            val triggerAt = SystemClock.elapsedRealtime() + INTERVAL_MILLIS
+            alarmManager.setRepeating(
+                AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                triggerAt,
+                INTERVAL_MILLIS,
+                pendingIntent
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- schedule repeating notifications every 10 minutes to remind users to check tasks
- register new TaskReminderReceiver and notification channel
- hook scheduler into MainActivity

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a4daccfaa48333925d1a1fd1ed7606