### PR TITLE
Add quick chat presets and productivity analysis

### DIFF
--- a/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
+++ b/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
@@ -27,6 +27,7 @@ import com.organizen.app.home.ui.ChatSection
 import kotlinx.coroutines.launch
 import com.organizen.app.home.data.ChatViewModel
 import com.organizen.app.home.data.TasksViewModel
+import com.organizen.app.home.data.HealthViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -37,6 +38,7 @@ fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
     val scope = rememberCoroutineScope()
     val chatViewModel: ChatViewModel = viewModel()
     val tasksViewModel: TasksViewModel = viewModel()
+    val healthViewModel: HealthViewModel = viewModel()
     ModalNavigationDrawer(
         drawerState = drawerState,
         drawerContent = {
@@ -90,7 +92,14 @@ fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
             ) {
                 composable(BottomNavScreen.Tasks.route) { TasksScreen(vm, tasksViewModel) }
                 composable(BottomNavScreen.Health.route) { HealthSection(vm, navController, chatViewModel, tasksViewModel) }
-                composable(BottomNavScreen.Chat.route) { ChatSection(chatViewModel = chatViewModel) }
+                composable(BottomNavScreen.Chat.route) {
+                    ChatSection(
+                        chatViewModel = chatViewModel,
+                        authVm = vm,
+                        tasksVm = tasksViewModel,
+                        healthVm = healthViewModel
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/organizen/app/home/data/ChatViewModel.kt
+++ b/app/src/main/java/com/organizen/app/home/data/ChatViewModel.kt
@@ -3,9 +3,9 @@ package com.organizen.app.home.data
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
 import ai.koog.prompt.llm.OllamaModels
+import android.annotation.SuppressLint
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.BuildConfig
 import com.organizen.app.home.models.Message
 import com.organizen.app.home.models.MessageType
 import kotlinx.coroutines.Dispatchers
@@ -66,6 +66,7 @@ class ChatViewModel: ViewModel() {
         }
     }
 
+    @SuppressLint("DefaultLocale")
     fun sendProductivityReport(tasks: List<Task>, steps: Long?, sleepHours: Double?) {
         if (uiState.value.agentIsTyping) {
             return
@@ -80,7 +81,7 @@ class ChatViewModel: ViewModel() {
                     Difficulty.EASY -> 1
                     Difficulty.MEDIUM -> 2
                     Difficulty.HARD -> 3
-                }
+                } as Int
             }
             val stepsGoal = 5000.0
             val sleepGoal = 7.0
@@ -94,7 +95,7 @@ class ChatViewModel: ViewModel() {
                 }
             val reply = buildString {
                 append("You've completed ${completedToday.size} tasks today")
-                if (breakdown.isNotBlank()) append(" (" + breakdown + ")")
+                if (breakdown.isNotBlank()) append(" ($breakdown)")
                 append(". Steps: ${(steps ?: 0L)}/5000, Sleep: ${String.format("%.1f", sleepHours ?: 0.0)}h of 7h.")
                 append(" Productivity score: ${String.format("%.2f", productivityScore)}")
             }

--- a/app/src/main/java/com/organizen/app/home/ui/ChatSection.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/ChatSection.kt
@@ -3,10 +3,12 @@ package com.organizen.app.home.ui
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -29,7 +31,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.organizen.app.auth.AuthViewModel
 import com.organizen.app.home.data.ChatViewModel
+import com.organizen.app.home.data.HealthViewModel
+import com.organizen.app.home.data.TasksViewModel
 import com.organizen.app.home.models.Message
 import com.organizen.app.home.models.MessageType
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -38,6 +43,9 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 fun ChatSection(
     modifier: Modifier = Modifier,
     chatViewModel: ChatViewModel = viewModel(),
+    authVm: AuthViewModel,
+    tasksVm: TasksViewModel,
+    healthVm: HealthViewModel = viewModel(),
 ) {
     val uiState by chatViewModel.uiState.collectAsState()
     val listState = rememberLazyListState()
@@ -91,12 +99,48 @@ fun ChatSection(
 
         Spacer(Modifier.height(8.dp))
 
+        QuickSuggestions(
+            onMindfulness = { chatViewModel.sendMessage("Mindfullness") },
+            onProductivity = {
+                val userId = authVm.currentUser?.uid ?: "guest"
+                val steps = healthVm.steps
+                val sleep = healthVm.sleepHours
+                chatViewModel.sendProductivityReport(
+                    tasksVm.tasksFor(userId),
+                    steps,
+                    sleep
+                )
+            }
+        )
+
+        Spacer(Modifier.height(8.dp))
+
         // INPUT BAR
         ChatInputBar(
             onSend = { text ->
                 if (text.isNotBlank()) chatViewModel.sendMessage(text)
             }
         )
+    }
+}
+
+@Composable
+private fun QuickSuggestions(
+    onMindfulness: () -> Unit,
+    onProductivity: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        OutlinedButton(onClick = onMindfulness) {
+            Text("Mindfullness")
+        }
+        OutlinedButton(onClick = onProductivity) {
+            Text("How productive I was today?")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add quick replies for "Mindfullness" and productivity review in chat
- compute daily productivity score from completed tasks, steps and sleep goals
- wire chat screen to use auth, tasks and health data

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dc8ae53c8333b0518ad02d55557b