### PR TITLE
Add chat quick actions and productivity report

### DIFF
--- a/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
+++ b/app/src/main/java/com/organizen/app/auth/ui/HomeScreen.kt
@@ -113,7 +113,14 @@ fun HomeScreen(vm: AuthViewModel, onLogout: () -> Unit) {
             ) {
                 composable(BottomNavScreen.Tasks.route) { TasksScreen(vm, tasksViewModel) }
                 composable(BottomNavScreen.Productivity.route) { ProductivitySection(vm, navController, chatViewModel, tasksViewModel, healthViewModel) }
-                composable(BottomNavScreen.Chat.route) { ChatSection(chatViewModel = chatViewModel) }
+                composable(BottomNavScreen.Chat.route) {
+                    ChatSection(
+                        chatViewModel = chatViewModel,
+                        authViewModel = vm,
+                        tasksViewModel = tasksViewModel,
+                        healthViewModel = healthViewModel,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/organizen/app/home/data/ChatViewModel.kt
+++ b/app/src/main/java/com/organizen/app/home/data/ChatViewModel.kt
@@ -30,6 +30,9 @@ class ChatViewModel: ViewModel() {
         }
     }
 
+    fun addUserMessage(text: String) = addMessage(text, MessageType.USER)
+    fun addAssistantMessage(text: String) = addMessage(text, MessageType.TOOL)
+
     fun sendMessage(string: String) {
         if (uiState.value.agentIsTyping) {
             return

--- a/app/src/main/java/com/organizen/app/home/data/HealthViewModel.kt
+++ b/app/src/main/java/com/organizen/app/home/data/HealthViewModel.kt
@@ -10,6 +10,7 @@ import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
 import ai.koog.prompt.llm.OllamaModels
 import android.app.Application
 import android.content.Context
+import com.google.firebase.auth.FirebaseAuth
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -27,14 +28,17 @@ import java.time.temporal.ChronoUnit
 class HealthViewModel(application: Application) : AndroidViewModel(application) {
     private val repo = HealthRepository(application)
     private val prefs = application.getSharedPreferences("targets", Context.MODE_PRIVATE)
+    private val uid = FirebaseAuth.getInstance().currentUser?.uid ?: "guest"
+    private val stepsKey = "stepsGoal_$uid"
+    private val sleepKey = "sleepGoal_$uid"
 
     var steps by mutableStateOf<Long?>(null)
         private set
     var sleepHours by mutableStateOf<Double?>(null)
         private set
-    var stepsGoal by mutableStateOf(prefs.getFloat("stepsGoal", 5000f))
+    var stepsGoal by mutableStateOf(prefs.getFloat(stepsKey, 5000f))
         private set
-    var sleepGoal by mutableStateOf(prefs.getFloat("sleepGoal", 7f).toDouble())
+    var sleepGoal by mutableStateOf(prefs.getFloat(sleepKey, 8f).toDouble())
         private set
 
     init {
@@ -56,11 +60,11 @@ class HealthViewModel(application: Application) : AndroidViewModel(application) 
 
     fun updateStepsGoal(value: Float) {
         stepsGoal = value
-        prefs.edit().putFloat("stepsGoal", value).apply()
+        prefs.edit().putFloat(stepsKey, value).apply()
     }
     fun updateSleepGoal(value: Double) {
         sleepGoal = value
-        prefs.edit().putFloat("sleepGoal", value.toFloat()).apply()
+        prefs.edit().putFloat(sleepKey, value.toFloat()).apply()
     }
 
     fun recommend() {

--- a/app/src/main/java/com/organizen/app/home/ui/ChatSection.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/ChatSection.kt
@@ -118,14 +118,14 @@ fun ChatSection(
                         Difficulty.EASY -> 1
                         Difficulty.MEDIUM -> 2
                         Difficulty.HARD -> 3
-                    }
+                    } as Int
                 }
                 val completedPoints = tasks.filter { it.completed }.sumOf {
                     when (it.difficulty) {
                         Difficulty.EASY -> 1
                         Difficulty.MEDIUM -> 2
                         Difficulty.HARD -> 3
-                    }
+                    } as Int
                 }
                 val taskScore = if (totalPoints == 0) 0.0 else completedPoints.toDouble() / totalPoints
                 val stepsRatio = (healthViewModel.steps?.toDouble() ?: 0.0) / healthViewModel.stepsGoal

--- a/app/src/main/java/com/organizen/app/home/ui/ChatSection.kt
+++ b/app/src/main/java/com/organizen/app/home/ui/ChatSection.kt
@@ -103,8 +103,8 @@ fun ChatSection(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            OutlinedButton(onClick = { chatViewModel.sendMessage("Mindfulness") }) {
-                Text("Mindfulness")
+            OutlinedButton(onClick = { chatViewModel.sendMessage("Mindfullness tips") }) {
+                Text("Mindfullness tips")
             }
             OutlinedButton(onClick = {
                 chatViewModel.addUserMessage("How productive I was today?")
@@ -128,10 +128,12 @@ fun ChatSection(
                     }
                 }
                 val taskScore = if (totalPoints == 0) 0.0 else completedPoints.toDouble() / totalPoints
-                val stepsScore = (healthViewModel.steps?.toDouble() ?: 0.0) / healthViewModel.stepsGoal
-                val sleepScore = (healthViewModel.sleepHours ?: 0.0) / healthViewModel.sleepGoal
-                val productivity = ((taskScore + stepsScore + sleepScore) / 3.0 * 100).roundToInt()
-                val msg = "Tasks done: ${easy + med + hard}/${tasks.size} (easy $easy, medium $med, hard $hard). Steps ${(healthViewModel.steps ?: 0L)}/${healthViewModel.stepsGoal.toInt()} (${(stepsScore*100).roundToInt()}%). Sleep ${"%.1f".format(healthViewModel.sleepHours ?: 0.0)}/${healthViewModel.sleepGoal}h (${(sleepScore*100).roundToInt()}%). Productivity score $productivity%."
+                val stepsRatio = (healthViewModel.steps?.toDouble() ?: 0.0) / healthViewModel.stepsGoal
+                val stepsScore = stepsRatio.coerceAtMost(1.0)
+                val sleepRatio = (healthViewModel.sleepHours ?: 0.0) / healthViewModel.sleepGoal
+                val sleepScore = if (sleepRatio <= 1) sleepRatio else (2 - sleepRatio).coerceAtLeast(0.0)
+                val productivity = ((taskScore * 0.5 + stepsScore * 0.25 + sleepScore * 0.25) * 100).roundToInt()
+                val msg = "Tasks done: ${easy + med + hard}/${tasks.size} (easy $easy, medium $med, hard $hard) – ${(taskScore*100).roundToInt()}%. Steps progress ${(stepsRatio*100).roundToInt()}%. Sleep progress ${(sleepScore*100).roundToInt()}%. Productivity score $productivity%."
                 chatViewModel.addAssistantMessage(msg)
             }) {
                 Text("How productive I was today?")


### PR DESCRIPTION
## Summary
- add helper functions in `ChatViewModel` for posting user/assistant messages
- display quick reply buttons in chat for "Mindfulness" and productivity report
- compute productivity score from tasks, steps and sleep data when requested

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f216214c83339711b4de04d4c118